### PR TITLE
Config docs update

### DIFF
--- a/cli/configuration.md
+++ b/cli/configuration.md
@@ -4,98 +4,107 @@ summary: How to configure the Denoflare CLI
 title: Configuration
 ---
 
-# .denoflare configuration file
+# .denoflare Configuration File
+
 How to configure the Denoflare CLI
 
-Most commands can be run using cli options, but sometimes it's easier to specify profiles and script defs in a .denoflare configuration file.
+Most commands can be run using CLI options, often it's easier to specify `profiles` and `scripts` definitions in configuration file.
 
-Specify your configuration in a jsonc file, and either
- - Specify it explicitly: e.g. `denoflare --config /path/to/my-config.jsonc`
- - Or save it with the filename `.denoflare` either in the current working directory, or any ancestors (e.g. `~/.denoflare` is common) and it will be used implicitly
+There are two ways to use the Denoflare CLI with a configuration file:
 
-## Example .denoflare file
+- The CLI will automatically look for a `.denoflare` file in the current directory.
+- You can specify a config file in another directory using the `--config` flag with an absolute path: e.g. `denoflare --config /path/to/my-config.jsonc`
+
+## Example .denoflare File
+
 ```jsonc
 {
-	// This jsonc file supports comments and trailing commas!
+    // This jsonc file supports comments and trailing commas!
 
     // optional schema to get auto-completions when editing this file in vscode, etc
-	"$schema": "https://raw.githubusercontent.com/skymethod/denoflare/v0.3.3/common/config.schema.json",
+    "$schema": "https://raw.githubusercontent.com/skymethod/denoflare/v0.3.3/common/config.schema.json",
 
     // define script configurations by name, and their associated bindings and options
     // you can then simply refer to them by name in your denoflare commands
     // note the same script source can be specified more than once with different configurations (local vs prod etc)
-	"scripts": {
-		"script1-local": {
-			"path": "/Users/me/path/to/script1.js",
-			"bindings": {
-				"foo": { "value": "bar" },
-			},
-			"localPort": 3002,
-		},
-		"script2-local": {
-			"path": "/Users/me/path/to/script2.ts",
-			"bindings": {
-				"memoryNamespace": { "doNamespace": "local:MyDO" }
-			},
-			"localPort": 8080,
-		},
-		"script3-local": {
-			"path": "/Users/me/path/to/script3.ts",
-			"bindings": {
-				"MyKV": { "kvNamespace": "351bddca004649b5a58c985b0gus86d5" },
-				"LocalHostAndPort": { "value": "localhost:${localPort}" }
-			},
-			"localPort": 3031,
-			"localHostname": "test.example.com",
-			"localIsolation": "isolate"
-		},
-		"script4-prod": {
-		    "path": "/Users/me/path/to/script4.ts",
-		    "bindings": {
-				"version": { "value": "1.2.3" },
-			},
-		},
-		"script4-local": {
-		    "path": "/Users/me/path/to/script4.ts", // same script, different binding value
-		    "bindings": {
-				"version": { "value": "local" },
-			},
-		},
-	},
+    "scripts": {
+        "script1-local": {
+            "path": "/Users/me/path/to/script1.js",
+            "bindings": {
+                "foo": { "value": "bar" },
+            },
+            "localPort": 3002,
+        },
+        "script2-local": {
+            "path": "/Users/me/path/to/script2.ts",
+            "bindings": {
+                "memoryNamespace": { "doNamespace": "local:MyDO" }
+            },
+            "localPort": 8080,
+        },
+        "script3-local": {
+            "path": "/Users/me/path/to/script3.ts",
+            "bindings": {
+                "MyKV": { "kvNamespace": "351bddca004649b5a58c985b0gus86d5" },
+                "LocalHostAndPort": { "value": "localhost:${localPort}" }
+            },
+            "localPort": 3031,
+            "localHostname": "test.example.com",
+            "localIsolation": "isolate"
+        },
+        "script4-prod": {
+            "path": "/Users/me/path/to/script4.ts",
+            "bindings": {
+                "version": { "value": "1.2.3" },
+            },
+        },
+        "script4-local": {
+            "path": "/Users/me/path/to/script4.ts", // same script, different binding value
+            "bindings": {
+                "version": { "value": "local" },
+            },
+        },
+    },
 
     // define one or more named profiles to specify Cloudflare API token credentials
     // you can then simply refer to them by name in your denoflare commands, using --profile <profile-name>
     // or if no --profile is specified, the default profile will be used
     // the default profile is either the only profile specified (as shown here), or the one marked with default: true
-	"profiles": {
-		"account1": {
-			"accountId": "4fc7a4becb8b41d887c5bb970b0guse1",
-			"apiToken": "kAE-bogUs-_d8fkg2kkjc8dsftq63jda9kgs78"
-		}
-	}
+    "profiles": {
+        "account1": {
+            "accountId": "4fc7a4becb8b41d887c5bb970b0guse1",
+            "apiToken": "kAE-bogUs-_d8fkg2kkjc8dsftq63jda9kgs78"
+        }
+    }
 }
 ```
 
-## Full configuration format
+## Full Configuration Format
+
+The Denoflare configuration object is typically saved in a `.denoflare` file.
+The top-level object supports two keys:
+
+- `scripts` is keyed by the name of each [Script](#script).
+- `profiles` is keyed by the name of each [Profile](#profile).
+
 ```ts
-/** Top-level Denoflare configuration object, typically saved in a `.denoflare` file. */
 export interface Config {
 
     /** Known script definitions, by unique `script-name`.
-     * 
+     *
      * `script-name` must:
      *  - start with a letter
      *  - end with a letter or digit
      *  - include only lowercase letters, digits, underscore, and hyphen
      *  - be 63 characters or less
-     * 
+     *
      * Only the name must be unique, multiple Script definitions can point to the same worker `path` but different Bindings.
      * This is useful when defining multiple environments for the same script, named `worker-local`, `worker-dev`, `worker-prod`, etc.
      */
     readonly scripts?: Record<string, Script>;
 
     /** Profile definitions by unique `profile-name`.
-     * 
+     *
      * `profile-name` must:
      *  - start with a letter
      *  - end with a letter or digit
@@ -104,17 +113,14 @@ export interface Config {
      */
     readonly profiles?: Record<string, Profile>;
 }
+```
 
-/** Code isolation to use when running worker scripts with `serve`, the local dev server.
- * 
- * - `'none'`:    Run the worker script in the same isolate as the host.
- *                Easier to debug, but no hot reloads, and same Deno permissions as the host.
- * - `'isolate'`: (default) Run the worker script in a separate isolate (webworker) with no Deno permissions.
- *                Harder to debug, but can be hot reloaded on script changes, and safer.
- */
-export type Isolation = 'none' | 'isolate';
+### Script
 
-/** Script-level configuration */
+The [top-level](#full-configuration-format) `scripts` object is keyed by the name of each script. Each script configuration object supports
+the following keys:
+
+```ts
 export interface Script {
 
     /** (required) Local file path, or https: url to a module-based worker entry point .ts, or a non-module-based worker bundled .js */
@@ -127,21 +133,37 @@ export interface Script {
     readonly localPort?: number;
 
     /** If specified, replace the hostname portion of the incoming `Request.url` at runtime to use this hostname instead of `localhost`.
-     * 
+     *
      * Useful if your worker does hostname-based routing. */
     readonly localHostname?: string;
 
     /** If specified, use this isolation level when running `serve`, the local dev server.
-     * 
+     *
      * (Default: 'isolate') */
     readonly localIsolation?: Isolation;
 
     /** If specified, use a specific, named Profile defined in `config.profiles`.
-     * 
+     *
      * (Default: the Profile marked as `default`, or the only Profile defined) */
     readonly profile?: string;
 }
 
+/** Code isolation to use when running worker scripts with `serve`, the local dev server.
+ *
+ * - `'none'`:    Run the worker script in the same isolate as the host.
+ *                Easier to debug, but no hot reloads, and same Deno permissions as the host.
+ * - `'isolate'`: (default) Run the worker script in a separate isolate (webworker) with no Deno permissions.
+ *                Harder to debug, but can be hot reloaded on script changes, and safer.
+ */
+export type Isolation = 'none' | 'isolate';
+```
+
+### Bindings
+
+Each [Script](#script) can have a bindings object which is keyed by binding name. Bindings give access to Environment
+Variables as well as Workers KV and Durable Object namespaces.
+
+```ts
 /** Binding definition for a worker script environment variable */
 export type Binding = TextBinding | SecretBinding | KVNamespaceBinding | DONamespaceBinding;
 
@@ -182,24 +204,30 @@ export interface DONamespaceBinding {
      */
     readonly doNamespace: string;
 }
+```
 
-/** Profile definition, Cloudflare credentials to use when deploying via `push`, or running locally with `serve` using real KV storage. */
+### Profile
+
+The [top-level](#full-configuration-format) `profiles` object is keyed by profile name. Each holds a Profile definition object containing
+Cloudflare credentials to use when deploying via `push`, or running locally with `serve` using real KV storage.
+
+```ts
 export interface Profile {
 
     /** Cloudflare Account ID: 32-char hex string.
-     * 
+     *
      * This value can either be specified directly, or using `regex:<file-path>:<pattern-with-capturing-group>` to grab the value from another file.
      */
     readonly accountId: string;
 
-    /** Cloudflare API token: Value obtained from the Cloudflare dashboard (My Profile -> [API Tokens](https://dash.cloudflare.com/profile/api-tokens)) when creating the token under this account. 
-     * 
+    /** Cloudflare API token: Value obtained from the Cloudflare dashboard (My Profile -> [API Tokens](https://dash.cloudflare.com/profile/api-tokens)) when creating the token under this account.
+     *
      * This value can either be specified directly, or using `regex:<file-path>:<pattern-with-capturing-group>` to grab the value from another file.
      */
     readonly apiToken: string;
 
-    /** If there are multiple profiles defined, choose this one as the default (when no `--profile` is explicitly specified or configured). 
-     * 
+    /** If there are multiple profiles defined, choose this one as the default (when no `--profile` is explicitly specified or configured).
+     *
      * There can only be one default profile.
     */
     readonly default?: boolean;


### PR DESCRIPTION
This splits the configuration into more bite-sized chunks.  It also does some light rearranging so that readers learn expanded topics as they move down the page.

This PR stands separate and is not based on the one I made earlier.

The biggest difference is that the giant code block containing all of the interfaces has been split up into sections with short headings.  The various sections also link between each other, making it easier to navigate:

![Screen Shot 2021-11-20 at 9 37 07 PM](https://user-images.githubusercontent.com/128857/142749798-37715c1c-b9c7-4e8f-8d78-79c882557d8c.jpg)

